### PR TITLE
Remove unused packages from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 streamlit
-pandas
 numpy
 scipy
 plotly
-matplotlib
-seaborn


### PR DESCRIPTION
## Summary
- prune pandas, matplotlib, and seaborn from requirements.txt

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*