### PR TITLE
Add adaptive step for numeric inputs

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,8 +8,33 @@ from BlackScholes import BlackScholes
 st.title("Black-Scholes Option Pricing")
 
 # Individual option parameters
-S = st.slider("Spot Price", min_value=10.0, max_value=200.0, value=100.0)
-K = st.slider("Strike Price", min_value=10.0, max_value=200.0, value=100.0)
+def _step(val: float) -> float:
+    """Return an appropriate step size based on the current value."""
+    return max(0.01, round(val * 0.01, 2))
+
+default_S = 100.0
+prev_S = st.session_state.get("spot_price", default_S)
+step_S = _step(prev_S)
+S = st.number_input(
+    "Spot Price",
+    min_value=0.0,
+    value=prev_S,
+    step=step_S,
+    key="spot_price",
+    format="%.4f",
+)
+
+default_K = 100.0
+prev_K = st.session_state.get("strike_price", default_K)
+step_K = _step(prev_K)
+K = st.number_input(
+    "Strike Price",
+    min_value=0.0,
+    value=prev_K,
+    step=step_K,
+    key="strike_price",
+    format="%.4f",
+)
 sigma = st.slider("Volatility", min_value=0.05, max_value=1.0, value=0.2)
 T = st.slider(
     "Time to Maturity (years)", min_value=0.01, max_value=2.0, value=1.0, step=0.01


### PR DESCRIPTION
## Summary
- let Spot and Strike inputs be `number_input` widgets
- derive `step` parameter dynamically as 1% of the current value

## Testing
- `python -m py_compile streamlit_app.py`