### PR TITLE
Fix pip install with Python 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ https://blackschole.streamlit.app/
 
 ## 🔧 Dependencies
 
-The application requires the following packages (see `requirements.txt` for exact versions):
+The application requires the following packages (see `requirements.txt` for exact versions). The
+numpy and scipy versions have been bumped to ensure wheels are available for Python 3.12 and later:
 
 - `streamlit`
 - `numpy`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 streamlit==1.32.0
-numpy==1.24.4
-scipy==1.10.1
+# Use numpy and scipy versions that provide wheels for Python 3.12
+numpy==1.26.4
+scipy==1.11.4
 plotly==5.18.0


### PR DESCRIPTION
## Summary
- update numpy and scipy versions in `requirements.txt`
- document Python 3.12 compatible versions in README

## Testing
- `pip list`