### PR TITLE
Improve option P&L visualizations

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -36,21 +36,24 @@ K = st.sidebar.number_input(
 )
 
 
-sigma_pct = st.sidebar.slider(
+sigma_pct = st.sidebar.number_input(
     "Volatility (%)",
-    min_value=5.0,
+    min_value=0.0,
     max_value=200.0,
     value=20.0,
+    step=0.001,
+    format="%.3f",
 )
 sigma = sigma_pct / 100.0
 
-T = st.sidebar.slider(
-    "Time to Maturity (years)",
-    min_value=0.01,
-    max_value=2.0,
-    value=1.0,
-    step=0.01,
+T_weeks = st.sidebar.slider(
+    "Time to Maturity (weeks)",
+    min_value=1,
+    max_value=104,
+    value=52,
+    step=1,
 )
+T = T_weeks / 52
 r = st.sidebar.slider(
     "Interest Rate", min_value=0.0, max_value=0.2, value=0.05, step=0.001
 )
@@ -82,6 +85,7 @@ vol_range = (vol_range_pct[0] / 100.0, vol_range_pct[1] / 100.0)
 
 S_grid = np.linspace(spot_range[0], spot_range[1], 50)
 vol_grid = np.linspace(vol_range[0], vol_range[1], 50)
+vol_grid_pct = vol_grid * 100
 call_grid = np.zeros((len(S_grid), len(vol_grid)))
 put_grid = np.zeros_like(call_grid)
 
@@ -96,49 +100,67 @@ call_payoff = np.maximum(S_grid[:, None] - K, 0)
 put_payoff = np.maximum(K - S_grid[:, None], 0)
 call_pnl_grid = call_payoff - call_grid
 put_pnl_grid = put_payoff - put_grid
+call_pnl_short = call_grid - call_payoff
+put_pnl_short = put_grid - put_payoff
 
 fig = make_subplots(
-    rows=2,
+    rows=3,
     cols=2,
     subplot_titles=(
         "Call Price",
         "Put Price",
-        "Call P&L at Expiry",
-        "Put P&L at Expiry",
+        "Long Call P&L at Expiry",
+        "Long Put P&L at Expiry",
+        "Short Call P&L at Expiry",
+        "Short Put P&L at Expiry",
     ),
     horizontal_spacing=0.15,
     vertical_spacing=0.25,
 )
 
 fig.add_trace(
-    go.Heatmap(x=vol_grid, y=S_grid, z=call_grid, colorscale="Viridis"),
+    go.Heatmap(x=vol_grid_pct, y=S_grid, z=call_grid, colorscale="Viridis"),
     row=1,
     col=1,
 )
 fig.add_trace(
-    go.Heatmap(x=vol_grid, y=S_grid, z=put_grid, colorscale="Viridis"),
+    go.Heatmap(x=vol_grid_pct, y=S_grid, z=put_grid, colorscale="Viridis"),
     row=1,
     col=2,
 )
 fig.add_trace(
-    go.Heatmap(x=vol_grid, y=S_grid, z=call_pnl_grid, colorscale="RdYlGn"),
+    go.Heatmap(x=vol_grid_pct, y=S_grid, z=call_pnl_grid, colorscale="RdYlGn", zmid=0),
     row=2,
     col=1,
 )
 fig.add_trace(
-    go.Heatmap(x=vol_grid, y=S_grid, z=put_pnl_grid, colorscale="RdYlGn"),
+    go.Heatmap(x=vol_grid_pct, y=S_grid, z=put_pnl_grid, colorscale="RdYlGn", zmid=0),
     row=2,
+    col=2,
+)
+fig.add_trace(
+    go.Heatmap(x=vol_grid_pct, y=S_grid, z=call_pnl_short, colorscale="RdYlGn", zmid=0),
+    row=3,
+    col=1,
+)
+fig.add_trace(
+    go.Heatmap(x=vol_grid_pct, y=S_grid, z=put_pnl_short, colorscale="RdYlGn", zmid=0),
+    row=3,
     col=2,
 )
 
-fig.update_xaxes(title_text="Volatility", row=1, col=1)
-fig.update_xaxes(title_text="Volatility", row=1, col=2)
-fig.update_xaxes(title_text="Volatility", row=2, col=1)
-fig.update_xaxes(title_text="Volatility", row=2, col=2)
+fig.update_xaxes(title_text="Volatility (%)", row=1, col=1)
+fig.update_xaxes(title_text="Volatility (%)", row=1, col=2)
+fig.update_xaxes(title_text="Volatility (%)", row=2, col=1)
+fig.update_xaxes(title_text="Volatility (%)", row=2, col=2)
+fig.update_xaxes(title_text="Volatility (%)", row=3, col=1)
+fig.update_xaxes(title_text="Volatility (%)", row=3, col=2)
 fig.update_yaxes(title_text="Spot Price", row=1, col=1)
 fig.update_yaxes(title_text="Spot Price", row=1, col=2)
 fig.update_yaxes(title_text="Spot Price", row=2, col=1)
 fig.update_yaxes(title_text="Spot Price", row=2, col=2)
+fig.update_yaxes(title_text="Spot Price", row=3, col=1)
+fig.update_yaxes(title_text="Spot Price", row=3, col=2)
 fig.update_layout(title="Option Price and P&L Heatmaps")
 
 st.plotly_chart(fig, use_container_width=True)


### PR DESCRIPTION
## Summary
- switch volatility input to a precise number field
- express time-to-maturity in weeks
- show volatility axis in percent
- add short call/put P&L heatmaps
- center all P&L heatmaps at zero

## Testing
- `python -m py_compile streamlit_app.py`
- ❌ `pytest -q` *(fails: `pytest` not found)*